### PR TITLE
Adding a hdfs-site.xml template for aws specific environments

### DIFF
--- a/schemer-registry/src/main/resources/aws-hdfs-site.xml
+++ b/schemer-registry/src/main/resources/aws-hdfs-site.xml
@@ -1,0 +1,16 @@
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+    Useful configurations if you're on AWS to use s3a filesystem that supports IAM Roles
+    instead of expecting hard-coded AWS keys.
+ -->
+<configuration>
+    <property>
+        <name>fs.s3.impl</name>
+        <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+    </property>
+    <property>
+        <name>fs.s3n.impl</name>
+        <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+    </property>
+</configuration>


### PR DESCRIPTION
One can rename the `aws-hdfs-site.xml` -> `hdfs-site.xml` as part of the build if schemer is being deployed on AWS. S3A has lot of advantages like using the AWS SDK for S3 Filesystem implementation and also supports IAM Roles based authentication while reading / writing files on S3. Both `s3` and `s3n` filesystems require `AWS_*` environment variables or `fs.*.aws*Key` properties to be present in the classpath.